### PR TITLE
Fix hitpoint function in Plane primitive

### DIFF
--- a/include/Primitives/Plane.hpp
+++ b/include/Primitives/Plane.hpp
@@ -51,31 +51,31 @@ namespace Primitive {
              * @return Point3D
              */
             Math::Point3D hitPoint(const Raytracer::Ray& ray) const override;
-            
+
             /**
              * @brief Get the Axis object
-             * 
+             *
              * @return Axis The axis of Plane Object
              */
             Primitive::Axis getAxis(void) const;
 
             /**
              * @brief Set the Axis object
-             * 
+             *
              * @param axis The axis of Plane Object to set
              */
             void setAxis(const Primitive::Axis &axis);
 
             /**
              * @brief Get the Position object plane
-             * 
+             *
              * @return Math::Point3D Position of Plane Object
              */
             Math::Point3D getPosition(void) const;
 
             /**
              * @brief Set the Position object
-             * 
+             *
              * @param position Position to set
              */
             void setPosition(Math::Point3D position);

--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -42,11 +42,11 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
     Math::Vector3D rayDirection = ray.direction();
 
     if (_axis == X && rayDirection.x() == 0)
-        return Math::Point3D(0, 0, 0);
+        return Math::Point3D(-1, -1, -1);
     if (_axis == Y && rayDirection.y() == 0)
-        return Math::Point3D(0, 0, 0);
+        return Math::Point3D(-1, -1, -1);
     if (_axis == Z && rayDirection.z() == 0)
-        return Math::Point3D(0, 0, 0);
+        return Math::Point3D(-1, -1, -1);
 
     double t = 0;
     if (_axis == X) {

--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -61,7 +61,11 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
         double pos = _position.z();
         t = (pos - rayOrigin.z()) / rayDirection.z();
     }
-    return rayDirection * t;
+
+    if (t < 0)
+        return Math::Point3D(-1, -1, -1);
+
+    return rayOrigin + rayDirection * t;
 }
 
 Primitive::Axis Primitive::Plane::getAxis(void) const


### PR DESCRIPTION
I fix the collision between a Ray and a Plane.

**Before my fix for fix the result seems like this:**
![image](https://github.com/Njord201/Raytracer/assets/114904525/affd1ffa-b88a-44ec-985a-7f53af11c49a)

**With this configuration file:**
![image](https://github.com/Njord201/Raytracer/assets/114904525/c135652d-f59d-49a0-af2f-bdfe947c2557)

**And now we have this result:**
![image](https://github.com/Njord201/Raytracer/assets/114904525/bcbce3f6-ec30-47c6-bab8-e88f51449623)
