### PR TITLE
fix: primitive plane if the camera origin is set in the Plane

### DIFF
--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -41,12 +41,21 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
 
-    if (_axis == X && rayDirection.x() == 0)
+    if (_axis == X && rayDirection.x() == 0) {
+        if (_position.x() == rayOrigin.x())
+            return rayOrigin;
         return Math::Point3D(-1, -1, -1);
-    if (_axis == Y && rayDirection.y() == 0)
+    }
+    if (_axis == Y && rayDirection.y() == 0) {
+        if (_position.y() == rayOrigin.y())
+            return rayOrigin;
         return Math::Point3D(-1, -1, -1);
-    if (_axis == Z && rayDirection.z() == 0)
+    }
+    if (_axis == Z && rayDirection.z() == 0) {
+        if (_position.z() == rayOrigin.z())
+            return rayOrigin;
         return Math::Point3D(-1, -1, -1);
+    }
 
     double t = 0;
     if (_axis == X) {


### PR DESCRIPTION
If the camera is placed in the Plane, the Plane's hitPoint function did not work.