### PR TITLE
fix: position of elements in sdl

### DIFF
--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -82,7 +82,7 @@ void Raytracer::Renderer::renderScene()
                 Color hit = _primitives.getColorPoint(r, _lights);
 
                 SDL_SetRenderDrawColor(ren, hit.getR(), hit.getG(), hit.getB(), 255);
-                SDL_RenderDrawPoint(ren, x, y);
+                SDL_RenderDrawPoint(ren, imageWidth - x, imageHeight - y);
             }
         }
         SDL_RenderPresent(ren);


### PR DESCRIPTION
Result before:
![image](https://github.com/Njord201/Raytracer/assets/114904525/c62867e8-cce4-4215-9fb4-3bf9c447e1f3)

Result now:
![image](https://github.com/Njord201/Raytracer/assets/114904525/7bdf2604-e16e-4028-9040-81a72bd74602)
