### PR TITLE
fix: visualization of primitives behind camera

### DIFF
--- a/include/Primitives/IPrimitive.hpp
+++ b/include/Primitives/IPrimitive.hpp
@@ -12,6 +12,7 @@
 #include "Lights/LightsContainer.hpp"
 
 #define IS_HIT(D) ((D >= 0) ? true : false)
+#define IS_INVERSE(X,Y) (((X > 0 && Y < 0) || (X < 0 && Y > 0)) ? true : false)
 
 namespace Primitive {
 

--- a/src/Plugins/Primitives/Cone/Cone.cpp
+++ b/src/Plugins/Primitives/Cone/Cone.cpp
@@ -63,6 +63,10 @@ Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
     if (_axis == Axis::Z && hitPoint.z() > _position.z())
         return Math::Point3D(-1,-1,-1);
 
+    Math::Vector3D rayOriginToHit = hitPoint - rayOrigin;
+    if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
+        return Math::Point3D(-1,-1,-1);
+
     return hitPoint;
 }
 

--- a/src/Plugins/Primitives/Cylinder/Cylinder.cpp
+++ b/src/Plugins/Primitives/Cylinder/Cylinder.cpp
@@ -71,6 +71,10 @@ Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
 
     Math::Point3D hitPoint = rayOrigin + rayDirection * hitValue;
 
+    Math::Vector3D rayOriginToHit = hitPoint - rayOrigin;
+    if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
+        return Math::Point3D(-1,-1,-1);
+
     return hitPoint;
 }
 

--- a/src/Plugins/Primitives/Sphere/Sphere.cpp
+++ b/src/Plugins/Primitives/Sphere/Sphere.cpp
@@ -35,6 +35,10 @@ Math::Point3D Primitive::Sphere::hitPoint(const Raytracer::Ray& ray) const
 
     Math::Point3D hitPoint = rayOrigin + rayDirection * hitValue;
 
+    Math::Vector3D rayOriginToHit = hitPoint - rayOrigin;
+    if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
+        return Math::Point3D(-1,-1,-1);
+
     return hitPoint;
 }
 


### PR DESCRIPTION
Fixing the hitpoint computation. If a primitives is placed behind the camera, it is not displayed.