### PR TITLE
refactor: directional light do not illuminate the primitives behind it

### DIFF
--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#define IS_INVERSE(X,Y) (((X > 0 && Y < 0) || (X < 0 && Y > 0)) ? true : false)
+
 namespace Math {
 
     /**

--- a/include/Primitives/IPrimitive.hpp
+++ b/include/Primitives/IPrimitive.hpp
@@ -14,7 +14,6 @@
 #include <memory>
 
 #define IS_HIT(D) ((D >= 0) ? true : false)
-#define IS_INVERSE(X,Y) (((X > 0 && Y < 0) || (X < 0 && Y > 0)) ? true : false)
 
 namespace Primitive {
 

--- a/src/Core/Primitives/Shadow.cpp
+++ b/src/Core/Primitives/Shadow.cpp
@@ -36,6 +36,11 @@ bool Primitives::Shadow::isShadow(const Math::Vector3D& vectorLightToPoint, cons
                 myRound(hit.y(), 0.001) == myRound(hitPoint.y(), 0.001) &&
                 myRound(hit.z(), 0.001) == myRound(hitPoint.z(), 0.001))
                 continue;
+            Math::Vector3D lightToHit = light - hit;
+            if (IS_INVERSE(vectorLightToPoint.x(), lightToHit.x()) ||
+                IS_INVERSE(vectorLightToPoint.y(), lightToHit.y()) ||
+                IS_INVERSE(vectorLightToPoint.z(), lightToHit.z()))
+                continue;
             return true;
         }
     }

--- a/src/Plugins/Lights/Directional/Directional.cpp
+++ b/src/Plugins/Lights/Directional/Directional.cpp
@@ -65,6 +65,11 @@ Math::Point3D Light::Directional::computeColor(Math::Vector3D primitiveNormal, c
     Math::Vector3D pr = primitiveNormal / primitiveNormal.length();
     Math::Vector3D dir = getDirection() / getDirection().length();
 
+    Math::Vector3D hit = hitPoint;
+    Math::Vector3D rayOriginToHit = hit - _position;
+    if (IS_INVERSE(rayOriginToHit.x(), dir.x()) || IS_INVERSE(rayOriginToHit.y(), dir.y()) || IS_INVERSE(rayOriginToHit.z(), dir.z()))
+        return Math::Point3D(0,0,0);
+
     color *= -pr.dot(dir);
 
     if (color.x() < 0)

--- a/src/Plugins/Lights/Directional/Directional.cpp
+++ b/src/Plugins/Lights/Directional/Directional.cpp
@@ -70,7 +70,12 @@ Color Light::Directional::computeColor(Math::Vector3D primitiveNormal, const Mat
     if (IS_INVERSE(rayOriginToHit.x(), dir.x()) || IS_INVERSE(rayOriginToHit.y(), dir.y()) || IS_INVERSE(rayOriginToHit.z(), dir.z()))
         return SHADOW_COLOR;
 
-    if (shadow.isShadow(dir * -1, hitPoint))
+    // Compute the Vector between the light and the hitpoint
+    // P(x) = O + D*t -> calcul a point on a vector
+    Math::Point3D pos = _position;
+    Math::Vector3D t = pos - hit / -1 * dir;
+
+    if (shadow.isShadow(dir * t.length() * -1, hitPoint))
         return SHADOW_COLOR;
 
     color *= -normal.dot(dir);

--- a/src/Plugins/Lights/Directional/Directional.cpp
+++ b/src/Plugins/Lights/Directional/Directional.cpp
@@ -5,8 +5,8 @@
 ** Dircetional
 */
 
-#include "Lights/Directional.hpp"
 #include "RaytracerRules.hpp"
+#include "Lights/Directional.hpp"
 
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
Before with the light placed between the two spheres:
![image](https://github.com/Njord201/Raytracer/assets/114564526/9f845a9c-36fa-4af3-ac87-7b3d78ca4ada)
Now with the refactor:
![image](https://github.com/Njord201/Raytracer/assets/114564526/8aef2a61-c105-4d72-aeb8-d50171f35e47)
