### PR TITLE
Handle rotation for primitives & camera

### DIFF
--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -99,7 +99,7 @@ namespace Math {
             void rotateY(double degrees);
 
             /**
-             * @brief Rotate a vector with an angle.
+             * @brief Rotate a vector with an angle on the axis X.
              * 
              * @param degrees how many to rotate
              */

--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -85,7 +85,7 @@ namespace Math {
             void translate(const Vector3D& ptr);
 
             /**
-             * @brief Rotate a vector with an angle.
+             * @brief Rotate a vector with an angle on the axis Z
              * 
              * @param degrees how many to rotate
              */

--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -85,14 +85,14 @@ namespace Math {
             void translate(const Vector3D& ptr);
 
             /**
-             * @brief Rotate a vector with an angle on the axis Z
+             * @brief Rotate a vector with an angle on the axis Z.
              * 
              * @param degrees how many to rotate
              */
             void rotateZ(double degrees);
 
             /**
-             * @brief Rotate a vector with an angle.
+             * @brief Rotate a vector with an angle on the axis Y.
              * 
              * @param degrees how many to rotate
              */

--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -82,6 +82,13 @@ namespace Math {
              */
             void translate(const Vector3D& ptr);
 
+            /**
+             * @brief rotate a vector with an angle
+             * 
+             * @param degrees how many to rotate
+             */
+            void rotateY(double degrees);
+
             Vector3D operator+(const Vector3D& ptr);
             Vector3D& operator+=(const Vector3D& ptr);
             Vector3D operator-(const Vector3D& ptr);

--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -87,21 +87,21 @@ namespace Math {
             /**
              * @brief Rotate a vector with an angle on the axis Z.
              * 
-             * @param degrees how many to rotate
+             * @param degrees - Rotation value
              */
             void rotateZ(double degrees);
 
             /**
              * @brief Rotate a vector with an angle on the axis Y.
              * 
-             * @param degrees how many to rotate
+             * @param degrees - Rotation value
              */
             void rotateY(double degrees);
 
             /**
              * @brief Rotate a vector with an angle on the axis X.
              * 
-             * @param degrees how many to rotate
+             * @param degrees - Rotation value
              */
             void rotateX(double degrees);
 

--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -83,11 +83,25 @@ namespace Math {
             void translate(const Vector3D& ptr);
 
             /**
-             * @brief rotate a vector with an angle
+             * @brief Rotate a vector with an angle.
+             * 
+             * @param degrees how many to rotate
+             */
+            void rotateZ(double degrees);
+
+            /**
+             * @brief Rotate a vector with an angle.
              * 
              * @param degrees how many to rotate
              */
             void rotateY(double degrees);
+
+            /**
+             * @brief Rotate a vector with an angle.
+             * 
+             * @param degrees how many to rotate
+             */
+            void rotateX(double degrees);
 
             Vector3D operator+(const Vector3D& ptr);
             Vector3D& operator+=(const Vector3D& ptr);

--- a/include/Primitives/Cone.hpp
+++ b/include/Primitives/Cone.hpp
@@ -77,6 +77,13 @@ namespace Primitive {
             void setMaterial(std::shared_ptr<Material::IMaterial> material);
 
             /**
+             * @brief Set the Rotation object.
+             * 
+             * @param rotation rotation of cone
+             */
+            void setRotation(Math::Vector3D rotation);
+
+            /**
              * @brief Get the Origin object.
              *
              * @return Origin of Cone
@@ -112,7 +119,15 @@ namespace Primitive {
              */
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
+            /**
+             * @brief Get the Vector Direction object.
+             * 
+             * @return Math::Vector3D Direction to return
+             */
+            Math::Vector3D getVectorDirection(void) const;
+
         private:
+            Math::Vector3D                       _rotation;
             Math::Point3D                        _position;
             double                               _angle;
             Axis                                 _axis;

--- a/include/Primitives/Cone.hpp
+++ b/include/Primitives/Cone.hpp
@@ -119,13 +119,6 @@ namespace Primitive {
              */
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
-            /**
-             * @brief Get the Vector Direction object.
-             * 
-             * @return Math::Vector3D Direction to return
-             */
-            Math::Vector3D getVectorDirection(void) const;
-
         private:
             Math::Vector3D                       _rotation;
             Math::Point3D                        _position;

--- a/include/Primitives/Cone.hpp
+++ b/include/Primitives/Cone.hpp
@@ -79,7 +79,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of cone
+             * @param rotation - Rotation value
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Cylinder.hpp
+++ b/include/Primitives/Cylinder.hpp
@@ -72,6 +72,13 @@ namespace Primitive {
             void setAxis(const Primitive::Axis &axis);
 
             /**
+             * @brief Set the Rotation object.
+             * 
+             * @param rotation rotation of cone
+             */
+            void setRotation(Math::Vector3D rotation);
+
+            /**
              * @brief Get the Material object.
              *
              * @return Material of cylinder
@@ -94,10 +101,10 @@ namespace Primitive {
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
         private:
-
-            Math::Point3D _origin;
-            double _radius;
-            Primitive::Axis _axis;
+            Math::Vector3D                       _rotation;
+            Math::Point3D                        _origin;
+            double                               _radius;
+            Primitive::Axis                      _axis;
             std::shared_ptr<Material::IMaterial> _material;
     };
 };

--- a/include/Primitives/Cylinder.hpp
+++ b/include/Primitives/Cylinder.hpp
@@ -74,7 +74,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of cylinder
+             * @param rotation - Rotation value
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Cylinder.hpp
+++ b/include/Primitives/Cylinder.hpp
@@ -74,7 +74,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of cone
+             * @param rotation rotation of cylinder
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Plane.hpp
+++ b/include/Primitives/Plane.hpp
@@ -63,7 +63,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of cone
+             * @param rotation rotation of plane
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Plane.hpp
+++ b/include/Primitives/Plane.hpp
@@ -61,6 +61,13 @@ namespace Primitive {
             void setAxis(const Primitive::Axis &axis);
 
             /**
+             * @brief Set the Rotation object.
+             * 
+             * @param rotation rotation of cone
+             */
+            void setRotation(Math::Vector3D rotation);
+
+            /**
              * @brief Get the Position object plane.
              *
              * @return Math::Point3D Position of Plane Object
@@ -97,6 +104,7 @@ namespace Primitive {
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
         private:
+            Math::Vector3D                          _rotation;
             Primitive::Axis                         _axis;
             Math::Point3D                           _position;
             std::shared_ptr<Material::IMaterial>    _material;

--- a/include/Primitives/Plane.hpp
+++ b/include/Primitives/Plane.hpp
@@ -63,7 +63,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of plane
+             * @param rotation - Rotation value
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Sphere.hpp
+++ b/include/Primitives/Sphere.hpp
@@ -71,7 +71,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of sphere
+             * @param rotation - Rotation value
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Sphere.hpp
+++ b/include/Primitives/Sphere.hpp
@@ -71,7 +71,7 @@ namespace Primitive {
             /**
              * @brief Set the Rotation object.
              * 
-             * @param rotation rotation of cone
+             * @param rotation rotation of sphere
              */
             void setRotation(Math::Vector3D rotation);
 

--- a/include/Primitives/Sphere.hpp
+++ b/include/Primitives/Sphere.hpp
@@ -69,6 +69,13 @@ namespace Primitive {
             void setMaterial(std::shared_ptr<Material::IMaterial> material);
 
             /**
+             * @brief Set the Rotation object.
+             * 
+             * @param rotation rotation of cone
+             */
+            void setRotation(Math::Vector3D rotation);
+
+            /**
              * @brief Get the Origin object.
              *
              * @return Origin of sphere
@@ -98,6 +105,7 @@ namespace Primitive {
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
         private:
+            Math::Vector3D                       _rotation;
             Math::Point3D                        _origin;
             double                               _radius;
             std::shared_ptr<Material::IMaterial> _material;

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -252,6 +252,15 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 throw ParserException("Wrong Axis for plane");
             }
 
+            if (coneArray[index].exists("rotation")) {
+                libconfig::Setting& rotationSetting = coneArray[index].lookup("rotation");
+                const libconfig::Setting &rotationX = rotationSetting["x"];
+                const libconfig::Setting &rotationY = rotationSetting["y"];
+                const libconfig::Setting &rotationZ = rotationSetting["z"];
+                Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
+                newCone->setRotation(rotation);
+            }
+
             std::string materialType;
             libconfig::Setting& material = coneArray[index].lookup("material");
             material.lookupValue("type", materialType);

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -164,6 +164,15 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
             newSphere->setRadius(radius);
             newSphere->setOrigin(origin);
 
+            if (sphereArray[index].exists("rotation")) {
+                libconfig::Setting& rotationSetting = sphereArray[index].lookup("rotation");
+                const libconfig::Setting &rotationX = rotationSetting["x"];
+                const libconfig::Setting &rotationY = rotationSetting["y"];
+                const libconfig::Setting &rotationZ = rotationSetting["z"];
+                Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
+                newSphere->setRotation(rotation);
+            }
+
             std::string materialType;
             libconfig::Setting& material = sphereArray[index].lookup("material");
             material.lookupValue("type", materialType);

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -211,6 +211,14 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
             } else {
                 throw ParserException("Wrong Axis for Cylinder");
             }
+            if (cylinderArray[index].exists("rotation")) {
+                libconfig::Setting& rotationSetting = cylinderArray[index].lookup("rotation");
+                const libconfig::Setting &rotationX = rotationSetting["x"];
+                const libconfig::Setting &rotationY = rotationSetting["y"];
+                const libconfig::Setting &rotationZ = rotationSetting["z"];
+                Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
+                newCylinder->setRotation(rotation);
+            }
             std::string materialType;
             libconfig::Setting& material = cylinderArray[index].lookup("material");
             material.lookupValue("type", materialType);

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -181,7 +181,6 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 newOrigin.translate(trans);
                 newSphere->setOrigin(newOrigin);
             }
-
             this->_primitives.add(newSphere);
         }
     }

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -313,6 +313,15 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 throw ParserException("Wrong Axis for plane");
             }
 
+            if (planeArray[index].exists("rotation")) {
+                libconfig::Setting& rotationSetting = planeArray[index].lookup("rotation");
+                const libconfig::Setting &rotationX = rotationSetting["x"];
+                const libconfig::Setting &rotationY = rotationSetting["y"];
+                const libconfig::Setting &rotationZ = rotationSetting["z"];
+                Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
+                newPlane->setRotation(rotation);
+            }
+
             std::string materialType;
             libconfig::Setting& material = planeArray[index].lookup("material");
             material.lookupValue("type", materialType);

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -220,6 +220,7 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
             } else {
                 throw ParserException("Wrong Axis for Cylinder");
             }
+
             if (cylinderArray[index].exists("rotation")) {
                 libconfig::Setting& rotationSetting = cylinderArray[index].lookup("rotation");
                 const libconfig::Setting &rotationX = rotationSetting["x"];
@@ -228,6 +229,7 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
                 newCylinder->setRotation(rotation);
             }
+            
             std::string materialType;
             libconfig::Setting& material = cylinderArray[index].lookup("material");
             material.lookupValue("type", materialType);

--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -60,6 +60,7 @@ void Raytracer::Renderer::renderScene()
                 auto invertedX = imageWidth - x - 1;
                 auto pixel_center = viewUpper_left + (pixelSizeU * (invertedX + 0.5)) + (pixelSizeV * (y + 0.5));
                 auto rayDirection = _camera.getOrigin() - pixel_center;
+
                 Raytracer::Ray r(_camera.getOrigin(), rayDirection);
                 Math::Point3D hit = _primitives.hitPoint(r, _lights);
                 writeColor(stream, hit);

--- a/src/Core/Renderer.cpp
+++ b/src/Core/Renderer.cpp
@@ -129,6 +129,10 @@ void Raytracer::Renderer::renderFinalScene()
                 auto pixel_center = viewUpper_left + (pixelSizeU * (invertedX + 0.5)) + (pixelSizeV * (y + 0.5));
                 auto rayDirection = _camera.getOrigin() - pixel_center;
 
+                rayDirection.rotateX(this->_camera.getRotation().x());
+                rayDirection.rotateY(this->_camera.getRotation().y());
+                rayDirection.rotateZ(this->_camera.getRotation().z());
+
                 Raytracer::Ray r(_camera.getOrigin(), rayDirection);
                 Math::Point3D hit = _primitives.hitPoint(r, _lights);
                 writeColor(stream, hit);

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
     try {
         Raytracer::Scene scene(argv[1]);
         Raytracer::Renderer renderer(scene);
-        // renderer.renderScene();
+        renderer.renderScene();
         renderer.renderFinalScene();
     } catch (const Raytracer::Scene::ParserException &parseError) {
         std::cerr << parseError.what() << std::endl;

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv)
     try {
         Raytracer::Scene scene(argv[1]);
         Raytracer::Renderer renderer(scene);
-        renderer.renderScene();
+        // renderer.renderScene();
         renderer.renderFinalScene();
     } catch (const Raytracer::Scene::ParserException &parseError) {
         std::cerr << parseError.what() << std::endl;

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -56,9 +56,13 @@ void Math::Vector3D::rotateY(double degrees)
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
 
-    this->_vector[0] = this->_vector[2] * sin_theta + this->_vector[0] * cos_theta;
-    this->_vector[1] = this->_vector[1];
-    this->_vector[2] = this->_vector[2] * cos_theta - this->_vector[0] * sin_theta;
+    double coordX = this->_vector[0];
+    double coordY = this->_vector[1];
+    double coordZ = this->_vector[2];
+
+    this->_vector[0] = coordZ * sin_theta + coordX * cos_theta;
+    this->_vector[1] = coordY;
+    this->_vector[2] = coordZ * cos_theta - coordX * sin_theta;
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -52,7 +52,10 @@ void Math::Vector3D::translate(const Vector3D& ptr)
 void Math::Vector3D::rotateY(double degrees)
 {
     double radians = degrees * M_PI / 180.0;
- 
+    
+    double cos_theta = std::cos(radians);
+    double sin_theta = std::sin(radians);
+
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -79,7 +79,6 @@ void Math::Vector3D::rotateY(double degrees) {
     this->_vector[2] = z * cos_theta - x * sin_theta;
 }
  
- 
 void Math::Vector3D::rotateX(double degrees) {
     double radians = degrees * M_PI / 180.0;
  

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -49,20 +49,50 @@ void Math::Vector3D::translate(const Vector3D& ptr)
     *this += ptr;
 }
 
-void Math::Vector3D::rotateY(double degrees)
-{
+void Math::Vector3D::rotateZ(double degrees) {
     double radians = degrees * M_PI / 180.0;
-    
+ 
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
+ 
+    double x = this->_vector[0];
+    double y = this->_vector[1];
+    double z = this->_vector[2];
 
-    double coordX = this->_vector[0];
-    double coordY = this->_vector[1];
-    double coordZ = this->_vector[2];
+    this->_vector[0] = x * cos_theta - y * sin_theta;
+    this->_vector[1] = x * sin_theta + y * cos_theta;
+    this->_vector[2] = z;
+}
 
-    this->_vector[0] = coordZ * sin_theta + coordX * cos_theta;
-    this->_vector[1] = coordY;
-    this->_vector[2] = coordZ * cos_theta - coordX * sin_theta;
+void Math::Vector3D::rotateY(double degrees) {
+    double radians = degrees * M_PI / 180.0;
+ 
+    double cos_theta = std::cos(radians);
+    double sin_theta = std::sin(radians);
+ 
+    double x = this->_vector[0];
+    double y = this->_vector[1];
+    double z = this->_vector[2];
+
+    this->_vector[0] = z * sin_theta + x * cos_theta;
+    this->_vector[1] = y;
+    this->_vector[2] = z * cos_theta - x * sin_theta;
+}
+ 
+ 
+void Math::Vector3D::rotateX(double degrees) {
+    double radians = degrees * M_PI / 180.0;
+ 
+    double cos_theta = std::cos(radians);
+    double sin_theta = std::sin(radians);
+ 
+    double x = this->_vector[0];
+    double y = this->_vector[1];
+    double z = this->_vector[2];
+
+    this->_vector[0] = x;
+    this->_vector[1] = y * cos_theta + z * sin_theta;
+    this->_vector[2] = -y * sin_theta + z * cos_theta;
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -57,7 +57,7 @@ void Math::Vector3D::rotateY(double degrees)
     double sin_theta = std::sin(radians);
 
     this->_vector[0] = this->_vector[2] * sin_theta + this->_vector[0] * cos_theta;
-
+    this->_vector[1] = this->_vector[1];
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -49,6 +49,12 @@ void Math::Vector3D::translate(const Vector3D& ptr)
     *this += ptr;
 }
 
+void Math::Vector3D::rotateY(double degrees)
+{
+    double radians = degrees * M_PI / 180.0;
+ 
+}
+
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)
 {
     return Vector3D(_vector[0] + ptr._vector[0], _vector[1] + ptr._vector[1], _vector[2] + ptr._vector[2]);

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -56,6 +56,8 @@ void Math::Vector3D::rotateY(double degrees)
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
 
+    this->_vector[0] = this->_vector[2] * sin_theta + this->_vector[0] * cos_theta;
+
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -58,6 +58,7 @@ void Math::Vector3D::rotateY(double degrees)
 
     this->_vector[0] = this->_vector[2] * sin_theta + this->_vector[0] * cos_theta;
     this->_vector[1] = this->_vector[1];
+    this->_vector[2] = this->_vector[2] * cos_theta - this->_vector[0] * sin_theta;
 }
 
 Math::Vector3D Math::Vector3D::operator+(const Vector3D& ptr)

--- a/src/Plugins/Primitives/Cone/Cone.cpp
+++ b/src/Plugins/Primitives/Cone/Cone.cpp
@@ -20,6 +20,9 @@ Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
 {
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
+    rayOrigin.rotateX(this->_rotation.x());
+    rayOrigin.rotateY(this->_rotation.y());
+    rayOrigin.rotateZ(this->_rotation.z());
     rayDirection.rotateX(this->_rotation.x());
     rayDirection.rotateY(this->_rotation.y());
     rayDirection.rotateZ(this->_rotation.z());
@@ -72,6 +75,9 @@ Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
     if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
         return Math::Point3D(-1,-1,-1);
 
+    hitPoint.rotateX(this->_rotation.x());
+    hitPoint.rotateY(this->_rotation.y());
+    hitPoint.rotateZ(this->_rotation.z());
     return hitPoint;
 }
 

--- a/src/Plugins/Primitives/Cone/Cone.cpp
+++ b/src/Plugins/Primitives/Cone/Cone.cpp
@@ -18,11 +18,6 @@ _position(origin), _angle(angle), _axis(axis), _material(material){}
 
 Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
 {
-    Math::Vector3D coneDirection = this->getVectorDirection();
-    coneDirection.rotateX(this->_rotation.x());
-    coneDirection.rotateY(this->_rotation.y());
-    coneDirection.rotateZ(this->_rotation.z());
-
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
     rayDirection.rotateX(this->_rotation.x());
@@ -78,19 +73,6 @@ Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
         return Math::Point3D(-1,-1,-1);
 
     return hitPoint;
-}
-
-Math::Vector3D Primitive::Cone::getVectorDirection(void) const
-{
-    if (_axis == Axis::X) {
-        return Math::Vector3D(1, 0, 0);
-    }
-    else if (_axis == Axis::Y) {
-        return Math::Vector3D(0, 1, 0);
-    }
-    else {
-        return Math::Vector3D(0, 0, 1);
-    }
 }
 
 void Primitive::Cone::setOrigin(Math::Point3D origin)

--- a/src/Plugins/Primitives/Cone/Cone.cpp
+++ b/src/Plugins/Primitives/Cone/Cone.cpp
@@ -18,13 +18,23 @@ _position(origin), _angle(angle), _axis(axis), _material(material){}
 
 Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
 {
+    Math::Vector3D coneDirection = this->getVectorDirection();
+    coneDirection.rotateX(this->_rotation.x());
+    coneDirection.rotateY(this->_rotation.y());
+    coneDirection.rotateZ(this->_rotation.z());
+
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
+    rayDirection.rotateX(this->_rotation.x());
+    rayDirection.rotateY(this->_rotation.y());
+    rayDirection.rotateZ(this->_rotation.z());
 
-    rayOrigin = Math::Point3D(rayOrigin.x(), rayOrigin.y(), rayOrigin.z());
-    rayDirection = Math::Point3D(rayDirection.x(), rayDirection.y(), rayDirection.z());
-
-    Math::Vector3D vectorConeToRay(rayOrigin.x() - _position.x(), rayOrigin.y() - _position.y(), rayOrigin.z() - _position.z());
+    Math::Vector3D vectorConeToRay(rayOrigin.x() - _position.x(),
+                                   rayOrigin.y() - _position.y(),
+                                   rayOrigin.z() - _position.z());
+    vectorConeToRay.rotateX(this->_rotation.x());
+    vectorConeToRay.rotateY(this->_rotation.y());
+    vectorConeToRay.rotateZ(this->_rotation.z());
 
     double a, b, c;
     double angle = _angle * M_PI / 180 / 2;
@@ -70,6 +80,19 @@ Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
     return hitPoint;
 }
 
+Math::Vector3D Primitive::Cone::getVectorDirection(void) const
+{
+    if (_axis == Axis::X) {
+        return Math::Vector3D(1, 0, 0);
+    }
+    else if (_axis == Axis::Y) {
+        return Math::Vector3D(0, 1, 0);
+    }
+    else {
+        return Math::Vector3D(0, 0, 1);
+    }
+}
+
 void Primitive::Cone::setOrigin(Math::Point3D origin)
 {
     this->_position = origin;
@@ -88,6 +111,11 @@ void Primitive::Cone::setAxis(Axis axis)
 void Primitive::Cone::setMaterial(std::shared_ptr<Material::IMaterial> material)
 {
     this->_material = material;
+}
+
+void Primitive::Cone::setRotation(Math::Vector3D rotation)
+{
+    this->_rotation = rotation;
 }
 
 Math::Point3D Primitive::Cone::getOrigin() const

--- a/src/Plugins/Primitives/Cone/Cone.cpp
+++ b/src/Plugins/Primitives/Cone/Cone.cpp
@@ -11,10 +11,10 @@
 
 using std::sqrt;
 
-Primitive::Cone::Cone() : _position(0,0,0), _angle(25), _axis(Axis::X), _material(nullptr){}
+Primitive::Cone::Cone() : _rotation(0,0,0), _position(0,0,0), _angle(25), _axis(Axis::X), _material(nullptr) {}
 
 Primitive::Cone::Cone(const Math::Point3D& origin, double angle, Axis axis, std::shared_ptr<Material::IMaterial> material) :
-_position(origin), _angle(angle), _axis(axis), _material(material){}
+_position(origin), _angle(angle), _axis(axis), _material(material) {}
 
 Math::Point3D Primitive::Cone::hitPoint(const Raytracer::Ray& ray) const
 {

--- a/src/Plugins/Primitives/Cylinder/Cylinder.cpp
+++ b/src/Plugins/Primitives/Cylinder/Cylinder.cpp
@@ -34,9 +34,13 @@ static Math::Point3D getRayOriginByAxis(const Raytracer::Ray& ray, const Primiti
     return rayOrigin;
 }
 
-static Math::Vector3D getRayDirectionByAxis(const Raytracer::Ray& ray, const Primitive::Axis axis)
+static Math::Vector3D getRayDirectionByAxis(const Raytracer::Ray& ray, const Primitive::Axis axis, Math::Point3D rotation)
 {
     Math::Vector3D rayDirection = ray.direction();
+
+    rayDirection.rotateX(rotation.x());
+    rayDirection.rotateY(rotation.y());
+    rayDirection.rotateZ(rotation.z());
 
     switch (axis) {
         case Primitive::X:
@@ -55,9 +59,15 @@ static Math::Vector3D getRayDirectionByAxis(const Raytracer::Ray& ray, const Pri
 Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
 {
     Math::Point3D rayOrigin = getRayOriginByAxis(ray, _axis);
-    Math::Vector3D rayDirection = getRayDirectionByAxis(ray, _axis);
+    Math::Vector3D rayDirection = getRayDirectionByAxis(ray, _axis, this->_rotation);
 
-    Math::Vector3D vectorCylinderToRay(rayOrigin.x() - _origin.x(), rayOrigin.y() - _origin.y(), rayOrigin.z() - _origin.z());
+    Math::Vector3D vectorCylinderToRay(rayOrigin.x() - _origin.x(),
+                                       rayOrigin.y() - _origin.y(),
+                                       rayOrigin.z() - _origin.z());
+    vectorCylinderToRay.rotateX(this->_rotation.x());
+    vectorCylinderToRay.rotateY(this->_rotation.y());
+    vectorCylinderToRay.rotateZ(this->_rotation.z());
+   
     double a = rayDirection.dot(rayDirection);
     double b = 2 * vectorCylinderToRay.dot(rayDirection);
     double c = vectorCylinderToRay.dot(vectorCylinderToRay) - _radius * _radius;
@@ -76,6 +86,12 @@ Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
         return Math::Point3D(-1,-1,-1);
 
     return hitPoint;
+}
+
+
+void Primitive::Cylinder::setRotation(Math::Vector3D rotation)
+{
+    this->_rotation = rotation;
 }
 
 void Primitive::Cylinder::setOrigin(const Math::Point3D& origin)

--- a/src/Plugins/Primitives/Cylinder/Cylinder.cpp
+++ b/src/Plugins/Primitives/Cylinder/Cylinder.cpp
@@ -93,7 +93,6 @@ Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
     return hitPoint;
 }
 
-
 void Primitive::Cylinder::setRotation(Math::Vector3D rotation)
 {
     this->_rotation = rotation;

--- a/src/Plugins/Primitives/Cylinder/Cylinder.cpp
+++ b/src/Plugins/Primitives/Cylinder/Cylinder.cpp
@@ -16,9 +16,12 @@ Primitive::Cylinder::Cylinder() : _origin(0,0,0), _radius(1), _axis(X){}
 
 Primitive::Cylinder::Cylinder(const Math::Point3D& origin, double radius, Primitive::Axis axis) : _origin(origin), _radius(radius), _axis(axis){}
 
-static Math::Point3D getRayOriginByAxis(const Raytracer::Ray& ray, const Primitive::Axis axis)
+static Math::Point3D getRayOriginByAxis(const Raytracer::Ray& ray, const Primitive::Axis axis, Math::Point3D rotation)
 {
     Math::Point3D rayOrigin = ray.origin();
+    rayOrigin.rotateX(rotation.x());
+    rayOrigin.rotateY(rotation.y());
+    rayOrigin.rotateZ(rotation.z());
 
     switch (axis) {
         case Primitive::X:
@@ -58,7 +61,7 @@ static Math::Vector3D getRayDirectionByAxis(const Raytracer::Ray& ray, const Pri
 
 Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
 {
-    Math::Point3D rayOrigin = getRayOriginByAxis(ray, _axis);
+    Math::Point3D rayOrigin = getRayOriginByAxis(ray, _axis, this->_rotation);
     Math::Vector3D rayDirection = getRayDirectionByAxis(ray, _axis, this->_rotation);
 
     Math::Vector3D vectorCylinderToRay(rayOrigin.x() - _origin.x(),
@@ -84,7 +87,9 @@ Math::Point3D Primitive::Cylinder::hitPoint(const Raytracer::Ray& ray) const
     Math::Vector3D rayOriginToHit = hitPoint - rayOrigin;
     if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
         return Math::Point3D(-1,-1,-1);
-
+    hitPoint.rotateX(this->_rotation.x());
+    hitPoint.rotateY(this->_rotation.y());
+    hitPoint.rotateZ(this->_rotation.z());
     return hitPoint;
 }
 

--- a/src/Plugins/Primitives/Cylinder/Cylinder.cpp
+++ b/src/Plugins/Primitives/Cylinder/Cylinder.cpp
@@ -12,7 +12,7 @@
 
 using std::sqrt;
 
-Primitive::Cylinder::Cylinder() : _origin(0,0,0), _radius(1), _axis(X){}
+Primitive::Cylinder::Cylinder() : _rotation(0,0,0), _origin(0,0,0), _radius(1), _axis(X){}
 
 Primitive::Cylinder::Cylinder(const Math::Point3D& origin, double radius, Primitive::Axis axis) : _origin(origin), _radius(radius), _axis(axis){}
 

--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -16,6 +16,7 @@ Primitive::Plane::Plane()
     _position = Math::Point3D(0, 0, 0);
     _axis = X;
     _material = nullptr;
+    _rotation = Math::Point3D(0,0,0);
 }
 
 Primitive::Plane::Plane(Primitive::Axis axis, double position, std::shared_ptr<Material::IMaterial> material)

--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -42,6 +42,9 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
 
+    rayOrigin.rotateX(this->_rotation.x());
+    rayOrigin.rotateY(this->_rotation.y());
+    rayOrigin.rotateZ(this->_rotation.z());
     rayDirection.rotateX(this->_rotation.x());
     rayDirection.rotateY(this->_rotation.y());
     rayDirection.rotateZ(this->_rotation.z());
@@ -79,7 +82,11 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
     if (t < 0)
         return Math::Point3D(-1, -1, -1);
 
-    return rayOrigin + rayDirection * t;
+    Math::Point3D hitpoint = rayOrigin + rayDirection * t;
+    hitpoint.rotateX(this->_rotation.x());
+    hitpoint.rotateY(this->_rotation.y());
+    hitpoint.rotateZ(this->_rotation.z());
+    return hitpoint;
 }
 
 Primitive::Axis Primitive::Plane::getAxis(void) const

--- a/src/Plugins/Primitives/Plane/Plane.cpp
+++ b/src/Plugins/Primitives/Plane/Plane.cpp
@@ -42,6 +42,10 @@ Math::Point3D Primitive::Plane::hitPoint(const Raytracer::Ray &ray) const
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
 
+    rayDirection.rotateX(this->_rotation.x());
+    rayDirection.rotateY(this->_rotation.y());
+    rayDirection.rotateZ(this->_rotation.z());
+
     if (_axis == X && rayDirection.x() == 0) {
         if (_position.x() == rayOrigin.x())
             return rayOrigin;
@@ -86,6 +90,11 @@ Primitive::Axis Primitive::Plane::getAxis(void) const
 void Primitive::Plane::setAxis(const Primitive::Axis &axis)
 {
     this->_axis = axis;
+}
+
+void Primitive::Plane::setRotation(Math::Vector3D rotation)
+{
+    this->_rotation = rotation;
 }
 
 Math::Point3D Primitive::Plane::getPosition(void) const

--- a/src/Plugins/Primitives/Sphere/Sphere.cpp
+++ b/src/Plugins/Primitives/Sphere/Sphere.cpp
@@ -20,8 +20,14 @@ Math::Point3D Primitive::Sphere::hitPoint(const Raytracer::Ray& ray) const
 {
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
+    rayDirection.rotateX(this->_rotation.x());
+    rayDirection.rotateY(this->_rotation.y());
+    rayDirection.rotateZ(this->_rotation.z());
 
     Math::Vector3D vectorSphereToRay(rayOrigin.x() - _origin.x(), rayOrigin.y() - _origin.y(), rayOrigin.z() - _origin.z());
+    vectorSphereToRay.rotateX(this->_rotation.x());
+    vectorSphereToRay.rotateY(this->_rotation.y());
+    vectorSphereToRay.rotateZ(this->_rotation.z());
     double a = rayDirection.dot(rayDirection);
     double b = 2 * vectorSphereToRay.dot(rayDirection);
     double c = vectorSphereToRay.dot(vectorSphereToRay) - _radius * _radius;
@@ -76,3 +82,9 @@ Math::Vector3D Primitive::Sphere::getNormal(const Math::Vector3D& hitPoint) cons
 {
     return Math::Vector3D (hitPoint.x() - _origin.x(), hitPoint.y() - _origin.y(), hitPoint.z() - _origin.z());
 }
+
+void Primitive::Sphere::setRotation(Math::Vector3D rotation)
+{
+    this->_rotation = rotation;
+}
+

--- a/src/Plugins/Primitives/Sphere/Sphere.cpp
+++ b/src/Plugins/Primitives/Sphere/Sphere.cpp
@@ -20,6 +20,9 @@ Math::Point3D Primitive::Sphere::hitPoint(const Raytracer::Ray& ray) const
 {
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
+    rayOrigin.rotateX(this->_rotation.x());
+    rayOrigin.rotateY(this->_rotation.y());
+    rayOrigin.rotateZ(this->_rotation.z());
     rayDirection.rotateX(this->_rotation.x());
     rayDirection.rotateY(this->_rotation.y());
     rayDirection.rotateZ(this->_rotation.z());
@@ -44,7 +47,9 @@ Math::Point3D Primitive::Sphere::hitPoint(const Raytracer::Ray& ray) const
     Math::Vector3D rayOriginToHit = hitPoint - rayOrigin;
     if (IS_INVERSE(rayOriginToHit.x(), rayDirection.x()) || IS_INVERSE(rayOriginToHit.y(), rayDirection.y()) || IS_INVERSE(rayOriginToHit.z(), rayDirection.z()))
         return Math::Point3D(-1,-1,-1);
-
+    hitPoint.rotateX(this->_rotation.x());
+    hitPoint.rotateY(this->_rotation.y());
+    hitPoint.rotateZ(this->_rotation.z());
     return hitPoint;
 }
 

--- a/src/Plugins/Primitives/Sphere/Sphere.cpp
+++ b/src/Plugins/Primitives/Sphere/Sphere.cpp
@@ -11,7 +11,7 @@
 
 using std::sqrt;
 
-Primitive::Sphere::Sphere() : _origin(0,0,0), _radius(1), _material(nullptr){}
+Primitive::Sphere::Sphere() : _rotation(0,0,0), _origin(0,0,0), _radius(1), _material(nullptr){}
 
 Primitive::Sphere::Sphere(const Math::Point3D& origin, double radius, std::shared_ptr<Material::IMaterial> material) :
 _origin(origin), _radius(radius), _material(material){}

--- a/tests/files_examples/subjects/rotation_test.cfg
+++ b/tests/files_examples/subjects/rotation_test.cfg
@@ -14,14 +14,23 @@ primitives :
 {
     # List of spheres
     spheres = (
+        # { x = 0; y = 0; z = 100; r = 25;  rotation = { x = 0.0; y = 0.0; z = 180.0; }; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};} },  # Sphere devant
         { x = 0; y = 100; z = 0; r = 25; material = { type = "flatColor"; color = { r = 0; g = 0; b = 255;};} },    # Sphere en haut
         { x = 0; y = 0; z = -100; r = 25; material = { type = "flatColor"; color = { r = 0; g = 255; b = 0;};} },   # Sphere derrière
         { x = 100; y = 0; z = 0; r = 25; material = { type = "flatColor"; color = { r = 255; g = 255; b = 0;};} }   # Sphere à droite
     ) ;
  
-    cones = (
-        { x = 0; y = 0; z = -100; angle = 45; axis="Y"; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} }
+    # cones = (
+    #     { x = 0; y = 0; z = 100; angle = 45; axis="X"; rotation = { x = 0.0; y = 0.0; z = 180.0; }; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} }
+    # );
+
+    cylinders = (
+        { x = 0; y = 0; z = 100; r = 25; axis="X"; rotation = { x = 0.0; y = 0.0; z = 45.0; }; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} }
     );
+
+    # planes = (
+    #     { position = -50; axis="Y"; rotation = { x = 0.0; y = 0.0; z = 0.0; }; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} }
+    # );
 };
  
 # Light configuration
@@ -32,13 +41,13 @@ lights :
  
     # List of point lights
     point = (
-        {x = 0; y = 200; z = 200;},
-        {x = 200; y = 50; z = 60;}
+        {x = 0; y = 200; z = 50;},
+        # {x = 200; y = 50; z = 60;}
     );
  
     # List of directional lights
-    directional = (
-        {position = {x = 400; y = 100; z = 500;};  direction = {x = 400; y = 100; z = 500;} },
-        {position = {x = 100; y = 50; z = 10;};  direction = {x = 5; y = 5; z = 5;} }
-    );
+    # directional = (
+    #     {position = {x = 400; y = 100; z = 500;};  direction = {x = 400; y = 100; z = 500;} },
+    #     {position = {x = 100; y = 50; z = 10;};  direction = {x = 5; y = 5; z = 5;} }
+    # );
 };

--- a/tests/files_examples/subjects/rotation_test.cfg
+++ b/tests/files_examples/subjects/rotation_test.cfg
@@ -1,38 +1,41 @@
 # Configuration of the camera
 # This files (subject.cfg, subject2.cfg, subject3.cfg) tests imports and loops in the imports
-
+ 
 camera :
 {
     resolution = { width = 1920; height = 1080; };
-    position = { x = 0.0; y = -0.0; z = 0.0; };
-    rotation = { x = 0.0; y = 0.0; z = 90.0; };
+    position = { x = 0.0; y = 0.0; z = 0.0; };
+    rotation = { x = 0.0; y = 0.0; z = 0.0; };
     fieldOfView = 72.0; # In degree
 };
-
+ 
 # Primitives in the scene
 primitives :
 {
     # List of spheres
     spheres = (
-        { x = 0; y = 100; z = 0; r = 25; material = { type = "flatColor"; color = { r = 0; g = 0; b = 255;};} },
-        { x = 0; y = 0; z = -100; r = 25; material = { type = "flatColor"; color = { r = 0; g = 255; b = 0;};} },
-        { x = 0; y = 0; z = 100; r = 25; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} },
-        { x = 100; y = 00; z = 0; r = 25; material = { type = "flatColor"; color = { r = 255; g = 255; b = 0;};} }
+        { x = 0; y = 100; z = 0; r = 25; material = { type = "flatColor"; color = { r = 0; g = 0; b = 255;};} },    # Sphere en haut
+        { x = 0; y = 0; z = -100; r = 25; material = { type = "flatColor"; color = { r = 0; g = 255; b = 0;};} },   # Sphere derrière
+        { x = 100; y = 0; z = 0; r = 25; material = { type = "flatColor"; color = { r = 255; g = 255; b = 0;};} }   # Sphere à droite
     ) ;
+ 
+    cones = (
+        { x = 0; y = 0; z = -100; angle = 45; axis="Y"; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} }
+    );
 };
-
+ 
 # Light configuration
 lights :
 {
     ambient = 0; # Multiplier of ambient light
     diffuse = 0.6; # Multiplier of diffuse light
-
+ 
     # List of point lights
     point = (
         {x = 0; y = 200; z = 200;},
         {x = 200; y = 50; z = 60;}
     );
-
+ 
     # List of directional lights
     directional = (
         {position = {x = 400; y = 100; z = 500;};  direction = {x = 400; y = 100; z = 500;} },

--- a/tests/files_examples/subjects/rotation_test.cfg
+++ b/tests/files_examples/subjects/rotation_test.cfg
@@ -1,0 +1,41 @@
+# Configuration of the camera
+# This files (subject.cfg, subject2.cfg, subject3.cfg) tests imports and loops in the imports
+
+camera :
+{
+    resolution = { width = 1920; height = 1080; };
+    position = { x = 0.0; y = -0.0; z = 0.0; };
+    rotation = { x = 0.0; y = 0.0; z = 90.0; };
+    fieldOfView = 72.0; # In degree
+};
+
+# Primitives in the scene
+primitives :
+{
+    # List of spheres
+    spheres = (
+        { x = 0; y = 100; z = 0; r = 25; material = { type = "flatColor"; color = { r = 0; g = 0; b = 255;};} },
+        { x = 0; y = 0; z = -100; r = 25; material = { type = "flatColor"; color = { r = 0; g = 255; b = 0;};} },
+        { x = 0; y = 0; z = 100; r = 25; material = { type = "flatColor"; color = { r = 255; g = 0; b = 0;};} },
+        { x = 100; y = 00; z = 0; r = 25; material = { type = "flatColor"; color = { r = 255; g = 255; b = 0;};} }
+    ) ;
+};
+
+# Light configuration
+lights :
+{
+    ambient = 0; # Multiplier of ambient light
+    diffuse = 0.6; # Multiplier of diffuse light
+
+    # List of point lights
+    point = (
+        {x = 0; y = 200; z = 200;},
+        {x = 200; y = 50; z = 60;}
+    );
+
+    # List of directional lights
+    directional = (
+        {position = {x = 400; y = 100; z = 500;};  direction = {x = 400; y = 100; z = 500;} },
+        {position = {x = 100; y = 50; z = 10;};  direction = {x = 5; y = 5; z = 5;} }
+    );
+};


### PR DESCRIPTION
Hello dear mates,

Here is my job about the rotation of camera and primitives.

All my brief have a Point and a Maj so Mister Tranchet/Valgrind you can't catch me on this point !

Here you can observe a rotation of a cylinders about 45 degrees on Z axis:
![image](https://github.com/Njord201/Raytracer/assets/114805962/110341f3-d861-43ad-8dca-863c3aaa3b87)


and without rotation:
![image](https://github.com/Njord201/Raytracer/assets/114805962/87982a85-d6c1-4e42-a765-4fb3ff2b3692)



Of course the light i up to the camera that mean that the cylinder receive light on his upside !
