### PR TITLE
Added RectangularCuboid Primitive

### DIFF
--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -98,6 +98,11 @@ namespace Math {
             Vector3D operator/(double n);
             Vector3D& operator/=(double n);
 
+            bool operator==(const Vector3D& ptr);
+            bool operator!=(const Vector3D& ptr);
+            bool operator<(const Vector3D& ptr);
+            bool operator>(const Vector3D& ptr);
+
         private:
 
             double _vector[3];

--- a/include/Parser/Factory.hpp
+++ b/include/Parser/Factory.hpp
@@ -20,6 +20,7 @@
 #include "Primitives/Cone.hpp"
 #include "Primitives/Cylinder.hpp"
 #include "Primitives/Plane.hpp"
+#include "Primitives/RectangularCuboid.hpp"
 #include "Lights/Point.hpp"
 #include "Lights/Ambient.hpp"
 #include "Lights/Directional.hpp"

--- a/include/Parser/Factory.hpp
+++ b/include/Parser/Factory.hpp
@@ -17,13 +17,13 @@
 
 #include "Parser/DLLoader.hpp"
 #include "Primitives/Sphere.hpp"
-#include "Primitives/Cone.hpp"
-#include "Primitives/Cylinder.hpp"
-#include "Primitives/Plane.hpp"
-#include "Primitives/RectangularCuboid.hpp"
 #include "Lights/Point.hpp"
 #include "Lights/Ambient.hpp"
+#include "Primitives/Cone.hpp"
+#include "Primitives/Plane.hpp"
 #include "Lights/Directional.hpp"
+#include "Primitives/Cylinder.hpp"
+#include "Primitives/RectangularCuboid.hpp"
 
 namespace Raytracer
 {

--- a/include/Primitives/RectangularCuboid.hpp
+++ b/include/Primitives/RectangularCuboid.hpp
@@ -29,7 +29,7 @@ namespace Primitive {
              * @param minY double min y of the rectangular cuboid
              * @param minZ double min z of the rectangular cuboid
              */
-            RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ);
+            RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ, std::shared_ptr<Material::IMaterial> material);
 
             /**
              * @brief Destroy the RectangularCuboid object
@@ -151,6 +151,13 @@ namespace Primitive {
              */
             Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
 
+            /**
+             * @brief Set the Rotation of the object.
+             *
+             * @param rotation - Rotation value
+             */
+            void setRotation(Math::Vector3D rotation);
+
         private:
 
             /**
@@ -170,6 +177,7 @@ namespace Primitive {
             double _minY;
             double _maxZ;
             double _minZ;
-            std::shared_ptr<Material::IMaterial> _material;
+            std::shared_ptr<Material::IMaterial>    _material;
+            Math::Vector3D                          _rotation;
     };
 };

--- a/include/Primitives/RectangularCuboid.hpp
+++ b/include/Primitives/RectangularCuboid.hpp
@@ -153,6 +153,17 @@ namespace Primitive {
 
         private:
 
+            /**
+             * @brief Check if the ray reach the primitive rectangular cuboid.
+             *
+             * @param t - coefficient ((x | y | z) - rayOrigin.(x | y | z) / rayDirection.(x | y | z)
+             * @param vDir - vector direction of the ray
+             * @param origin - origin of the ray
+             * @return hitPoint if the ray reach the primitive or
+             * @return (-1, -1, -1) if the ray doesn't reach the primitive
+             */
+            Math::Point3D checkRayReachPrimitive(double t, Math::Vector3D vDir, Math::Point3D origin) const;
+
             double _maxX;
             double _minX;
             double _maxY;

--- a/include/Primitives/RectangularCuboid.hpp
+++ b/include/Primitives/RectangularCuboid.hpp
@@ -32,7 +32,7 @@ namespace Primitive {
             RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ, std::shared_ptr<Material::IMaterial> material);
 
             /**
-             * @brief Destroy the RectangularCuboid object
+             * @brief Destroy the RectangularCuboid object.
              *
              */
             ~RectangularCuboid() = default;

--- a/include/Primitives/RectangularCuboid.hpp
+++ b/include/Primitives/RectangularCuboid.hpp
@@ -28,6 +28,7 @@ namespace Primitive {
              * @param minX double min x of the rectangular cuboid
              * @param minY double min y of the rectangular cuboid
              * @param minZ double min z of the rectangular cuboid
+             * @param material Material of the rectangular cuboid
              */
             RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ, std::shared_ptr<Material::IMaterial> material);
 
@@ -171,12 +172,12 @@ namespace Primitive {
              */
             Math::Point3D checkRayReachPrimitive(double t, Math::Vector3D vDir, Math::Point3D origin) const;
 
-            double _maxX;
-            double _minX;
-            double _maxY;
-            double _minY;
-            double _maxZ;
-            double _minZ;
+            double                                  _maxX;
+            double                                  _minX;
+            double                                  _maxY;
+            double                                  _minY;
+            double                                  _maxZ;
+            double                                  _minZ;
             std::shared_ptr<Material::IMaterial>    _material;
             Math::Vector3D                          _rotation;
     };

--- a/include/Primitives/RectangularCuboid.hpp
+++ b/include/Primitives/RectangularCuboid.hpp
@@ -1,0 +1,164 @@
+/*
+** EPITECH PROJECT, 2024
+** Raytracer
+** File description:
+** RectangularCuboid
+*/
+
+#include "IPrimitive.hpp"
+
+namespace Primitive {
+
+    class RectangularCuboid : public IPrimitive {
+
+        public:
+
+            /**
+             * @brief Construct a new RectangularCuboid object.
+             *
+             */
+            RectangularCuboid();
+
+            /**
+             * @brief Construct a new RectangularCuboid object.
+             *
+             * @param maxX double max x of the rectangular cuboid
+             * @param maxY double max y of the rectangular cuboid
+             * @param maxZ double max z of the rectangular cuboid
+             * @param minX double min x of the rectangular cuboid
+             * @param minY double min y of the rectangular cuboid
+             * @param minZ double min z of the rectangular cuboid
+             */
+            RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ);
+
+            /**
+             * @brief Destroy the RectangularCuboid object
+             *
+             */
+            ~RectangularCuboid() = default;
+
+            /**
+             * @brief Return the hit point of the rectangular cuboid.
+             *
+             * @param ray vector3D
+             * @return Point3D
+             */
+            Math::Point3D hitPoint(const Raytracer::Ray& ray) const override;
+
+            /**
+             * @brief Get the min x value.
+             *
+             * @return double | min x value.
+             */
+            double getMinX() const;
+
+            /**
+             * @brief Get the min y value.
+             *
+             * @return double | min y value.
+             */
+            double getMinY() const;
+
+            /**
+             * @brief Get the min z value.
+             *
+             * @return double | min z value.
+             */
+            double getMinZ() const;
+
+            /**
+             * @brief Get the max x value.
+             *
+             * @return double | max x value.
+             */
+            double getMaxX() const;
+
+            /**
+             * @brief Get the max y value.
+             *
+             * @return double | max y value.
+             */
+            double getMaxY() const;
+
+            /**
+             * @brief Get the max z value.
+             *
+             * @return double | max z value.
+             */
+            double getMaxZ() const;
+
+            /**
+             * @brief Set the min x value.
+             *
+             * @param minX double min x value.
+             */
+            void setMinX(double minX);
+
+            /**
+             * @brief Set the min y value.
+             *
+             * @param minY double min y value.
+             */
+            void setMinY(double minY);
+
+            /**
+             * @brief Set the min z value.
+             *
+             * @param minZ double min z value.
+             */
+            void setMinZ(double minZ);
+
+            /**
+             * @brief Set the max x value.
+             *
+             * @param maxX double max x value.
+             */
+            void setMaxX(double maxX);
+
+            /**
+             * @brief Set the max y value.
+             *
+             * @param maxY double max y value.
+             */
+            void setMaxY(double maxY);
+
+            /**
+             * @brief Set the max z value.
+             *
+             * @param maxZ double max z value.
+             */
+            void setMaxZ(double maxZ);
+
+            /**
+             * @brief Get the Material object.
+             *
+             * @return Material of rectangular cuboid
+             */
+            std::shared_ptr<Material::IMaterial> getMaterial() const;
+
+            /**
+             * @brief Set the Material object.
+             *
+             * @param material Material of rectangular cuboid
+             */
+            void setMaterial(std::shared_ptr<Material::IMaterial> material);
+
+            /**
+             * @brief Get the Normal of the object.
+             *
+             * @param hitPoint to have the normal
+             * @return Math::Vector3D
+             */
+            Math::Vector3D getNormal(const Math::Vector3D& hitPoint) const override;
+
+        private:
+
+            double _maxX;
+            double _minX;
+            double _maxY;
+            double _minY;
+            double _maxZ;
+            double _minZ;
+            std::shared_ptr<Material::IMaterial> _material;
+    };
+};

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -31,6 +31,7 @@ SRC			=	Parser/Scene.cpp \
 				../Plugins/Primitives/Cone/Cone.cpp \
 				../Plugins/Primitives/Cylinder/Cylinder.cpp \
 				../Plugins/Primitives/Plane/Plane.cpp \
+				../Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp \
 				\
 				../Plugins/Lights/Ambient/Ambient.cpp \
 				../Plugins/Lights/Point/Point.cpp \

--- a/src/Core/Parser/Factory.cpp
+++ b/src/Core/Parser/Factory.cpp
@@ -23,6 +23,8 @@ Raytracer::Factory::Factory()
     this->_libraryLoader.push_back(directionalLoader);
     std::shared_ptr<DLLoader> cylinderLoader = std::make_shared<DLLoader>("plugins/raytracer_cylinder.so");
     this->_libraryLoader.push_back(cylinderLoader);
+    std::shared_ptr<DLLoader> rectangularCuboidLoader = std::make_shared<DLLoader>("plugins/raytracer_rectangular_cuboid.so");
+
     this->registerPrimitivesComponent("sphere", [sphereLoader]() -> std::shared_ptr<Primitive::IPrimitive> {
         Primitive::IPrimitive *sphere = sphereLoader->getInstance<Primitive::IPrimitive *>("getSphereInstance");
         std::shared_ptr<Primitive::IPrimitive> sharedPtrSphere(sphere);
@@ -57,6 +59,11 @@ Raytracer::Factory::Factory()
         Light::ILight *directional = directionalLoader->getInstance<Light::ILight *>("getDirectionalInstance");
         std::shared_ptr<Light::ILight> sharedPtrDirectional(directional);
         return sharedPtrDirectional;
+    });
+    this->registerPrimitivesComponent("rectangular_cuboid", [rectangularCuboidLoader]() -> std::shared_ptr<Primitive::IPrimitive> {
+        Primitive::IPrimitive *rectangularCuboid = rectangularCuboidLoader->getInstance<Primitive::IPrimitive *>("getRectangularCuboidInstance");
+        std::shared_ptr<Primitive::IPrimitive> sharedPtrRectangularCuboid(rectangularCuboid);
+        return sharedPtrRectangularCuboid;
     });
 }
 

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -376,13 +376,24 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 newRectangularCuboid->setMaterial(materialPtr);
             }
 
-            // if (rectangularCuboidArray[index].exists("translation")) {
-            //     libconfig::Setting& translation = rectangularCuboidArray[index].lookup("translation");
-            //     Math::Vector3D trans(_parseValue(translation["x"]), _parseValue(translation["y"]), _parseValue(translation["z"]));
-            //     Math::Vector3D newOrigin = newRectangularCuboid->getOrigin();
-            //     newOrigin.translate(trans);
-            //     newRectangularCuboid->setOrigin(newOrigin);
-            // }
+            if (rectangularCuboidArray[index].exists("translation")) {
+                libconfig::Setting& translation = rectangularCuboidArray[index].lookup("translation");
+                Math::Vector3D trans(_parseValue(translation["x"]), _parseValue(translation["y"]), _parseValue(translation["z"]));
+
+                double newMinX = newRectangularCuboid->getMinX() + trans.x();
+                double newMinY = newRectangularCuboid->getMinY() + trans.y();
+                double newMinZ = newRectangularCuboid->getMinZ() + trans.z();
+                double newMaxX = newRectangularCuboid->getMaxX() + trans.x();
+                double newMaxY = newRectangularCuboid->getMaxY() + trans.y();
+                double newMaxZ = newRectangularCuboid->getMaxZ() + trans.z();
+
+                newRectangularCuboid->setMinX(newMinX);
+                newRectangularCuboid->setMinY(newMinY);
+                newRectangularCuboid->setMinZ(newMinZ);
+                newRectangularCuboid->setMaxX(newMaxX);
+                newRectangularCuboid->setMaxY(newMaxY);
+                newRectangularCuboid->setMaxZ(newMaxZ);
+            }
 
             this->_primitives.add(newRectangularCuboid);
         }

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -310,6 +310,47 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
             this->_primitives.add(newPlane);
         }
     }
+    if (primitives.exists("rectangular_cuboids")) {
+        libconfig::Setting& rectangularCuboidArray = primitives.lookup("rectangular_cuboids");
+        for (int index = 0; index < rectangularCuboidArray.getLength(); index++) {
+            std::shared_ptr<Primitive::IPrimitive> rectangularCuboid = _factory.createPrimitivesComponent("rectangular_cuboid");
+            std::shared_ptr<Primitive::RectangularCuboid> newRectangularCuboid = std::dynamic_pointer_cast<Primitive::RectangularCuboid>(rectangularCuboid);
+
+            const libconfig::Setting &minX = rectangularCuboidArray[index]["minX"];
+            const libconfig::Setting &minY = rectangularCuboidArray[index]["minY"];
+            const libconfig::Setting &minZ = rectangularCuboidArray[index]["minZ"];
+            const libconfig::Setting &maxX = rectangularCuboidArray[index]["maxX"];
+            const libconfig::Setting &maxY = rectangularCuboidArray[index]["maxY"];
+            const libconfig::Setting &maxZ = rectangularCuboidArray[index]["maxZ"];
+
+            newRectangularCuboid->setMinX(_parseValue(minX));
+            newRectangularCuboid->setMinY(_parseValue(minY));
+            newRectangularCuboid->setMinZ(_parseValue(minZ));
+            newRectangularCuboid->setMaxX(_parseValue(maxX));
+            newRectangularCuboid->setMaxY(_parseValue(maxY));
+            newRectangularCuboid->setMaxZ(_parseValue(maxZ));
+
+            std::string materialType;
+            libconfig::Setting& material = rectangularCuboidArray[index].lookup("material");
+            material.lookupValue("type", materialType);
+
+            if (materialType == "flatColor") {
+                libconfig::Setting& color = material.lookup("color");
+                std::shared_ptr<FlatColor> materialPtr = std::make_shared<FlatColor>(color["r"], color["g"], color["b"]);
+                newRectangularCuboid->setMaterial(materialPtr);
+            }
+
+            // if (rectangularCuboidArray[index].exists("translation")) {
+            //     libconfig::Setting& translation = rectangularCuboidArray[index].lookup("translation");
+            //     Math::Vector3D trans(_parseValue(translation["x"]), _parseValue(translation["y"]), _parseValue(translation["z"]));
+            //     Math::Vector3D newOrigin = newRectangularCuboid->getOrigin();
+            //     newOrigin.translate(trans);
+            //     newRectangularCuboid->setOrigin(newOrigin);
+            // }
+
+            this->_primitives.add(newRectangularCuboid);
+        }
+    }
     return 0;
 }
 

--- a/src/Core/Parser/Scene.cpp
+++ b/src/Core/Parser/Scene.cpp
@@ -395,6 +395,15 @@ int Raytracer::Scene::_parsePrimitiveSetting(const libconfig::Setting &primitive
                 newRectangularCuboid->setMaxZ(newMaxZ);
             }
 
+            if (rectangularCuboidArray[index].exists("rotation")) {
+                libconfig::Setting& rotationSetting = rectangularCuboidArray[index].lookup("rotation");
+                const libconfig::Setting &rotationX = rotationSetting["x"];
+                const libconfig::Setting &rotationY = rotationSetting["y"];
+                const libconfig::Setting &rotationZ = rotationSetting["z"];
+                Math::Vector3D rotation(_parseValue(rotationX), _parseValue(rotationY), _parseValue(rotationZ));
+                newRectangularCuboid->setRotation(rotation);
+            }
+
             this->_primitives.add(newRectangularCuboid);
         }
     }

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -132,3 +132,23 @@ Math::Vector3D& Math::Vector3D::operator/=(double n)
 
     return *this;
 }
+
+bool Math::Vector3D::operator==(const Vector3D& ptr)
+{
+    return _vector[0] == ptr._vector[0] && _vector[1] == ptr._vector[1] && _vector[2] == ptr._vector[2];
+}
+
+bool Math::Vector3D::operator!=(const Vector3D& ptr)
+{
+    return _vector[0] != ptr._vector[0] || _vector[1] != ptr._vector[1] || _vector[2] != ptr._vector[2];
+}
+
+bool Math::Vector3D::operator<(const Vector3D& ptr)
+{
+    return _vector[0] < ptr._vector[0] && _vector[1] < ptr._vector[1] && _vector[2] < ptr._vector[2];
+}
+
+bool Math::Vector3D::operator>(const Vector3D& ptr)
+{
+    return _vector[0] > ptr._vector[0] && _vector[1] > ptr._vector[1] && _vector[2] > ptr._vector[2];
+}

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -51,10 +51,10 @@ void Math::Vector3D::translate(const Vector3D& ptr)
 
 void Math::Vector3D::rotateZ(double degrees) {
     double radians = degrees * M_PI / 180.0;
- 
+
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
- 
+
     double x = this->_vector[0];
     double y = this->_vector[1];
     double z = this->_vector[2];
@@ -66,10 +66,10 @@ void Math::Vector3D::rotateZ(double degrees) {
 
 void Math::Vector3D::rotateY(double degrees) {
     double radians = degrees * M_PI / 180.0;
- 
+
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
- 
+
     double x = this->_vector[0];
     double y = this->_vector[1];
     double z = this->_vector[2];
@@ -78,13 +78,13 @@ void Math::Vector3D::rotateY(double degrees) {
     this->_vector[1] = y;
     this->_vector[2] = z * cos_theta - x * sin_theta;
 }
- 
+
 void Math::Vector3D::rotateX(double degrees) {
     double radians = degrees * M_PI / 180.0;
- 
+
     double cos_theta = std::cos(radians);
     double sin_theta = std::sin(radians);
- 
+
     double x = this->_vector[0];
     double y = this->_vector[1];
     double z = this->_vector[2];

--- a/src/Plugins/Primitives/Makefile
+++ b/src/Plugins/Primitives/Makefile
@@ -10,17 +10,20 @@ all:
 	@make -C ./Plane/
 	@make -C ./Cylinder/
 	@make -C ./Cone/
+	@make -C ./RectangularCuboid/
 
 clean:
 	@make clean -C ./Sphere/
 	@make clean -C ./Plane/
 	@make clean -C ./Cylinder/
 	@make clean -C ./Cone/
+	@make clean -C ./RectangularCuboid/
 
 fclean: clean
 	@make fclean -C ./Sphere/
 	@make fclean -C ./Plane/
 	@make fclean -C ./Cylinder/
 	@make fclean -C ./Cone/
+	@make fclean -C ./RectangularCuboid/
 
 re:	fclean all

--- a/src/Plugins/Primitives/RectangularCuboid/Makefile
+++ b/src/Plugins/Primitives/RectangularCuboid/Makefile
@@ -17,7 +17,7 @@ SRC			= 	getInstance.cpp \
 OBJ			= $(SRC:.cpp=.o)
 
 #Name
-NAME		= raytracer_cylinder.so
+NAME		= raytracer_rectangular_cuboid.so
 
 #Path
 ROOT		= ../../../../

--- a/src/Plugins/Primitives/RectangularCuboid/Makefile
+++ b/src/Plugins/Primitives/RectangularCuboid/Makefile
@@ -1,0 +1,60 @@
+##
+## EPITECH PROJECT, 2024
+## Raytracer
+## File description:
+## Makefile
+##
+
+#Files
+SRC			= 	getInstance.cpp \
+				RectangularCuboid.cpp \
+				../../../Math/Vector3D.cpp \
+				../../../Core/Ray.cpp \
+				../../../Core/Lights/LightsContainer.cpp \
+				../../../Core/Materials/FlatColor.cpp \
+				../../../Core/Color.cpp\
+
+OBJ			= $(SRC:.cpp=.o)
+
+#Name
+NAME		= raytracer_cylinder.so
+
+#Path
+ROOT		= ../../../../
+
+# Flags
+FLD_PLUGINS = $(ROOT)plugins/
+
+INCLUDE		=	-I$(ROOT)include/ -I$(ROOT)include/Primitives/ \
+				-I$(ROOT)include/Math/
+CXXFLAGS 	= 	-Werror -Wall -Wextra -g -rdynamic -std=c++20 $(INCLUDE)
+SHARED 		= 	-shared
+FPIC 		= 	-fPIC
+
+# Colors
+YELLOW 			= /bin/echo -e "\x1b[33m $1\x1b[0m"
+GREEN 			= /bin/echo -e "\x1b[32m $1\x1b[0m"
+
+CC = g++
+
+all: $(NAME)
+
+$(NAME): $(OBJ)
+	@$(CC) $(SHARED) -o $(FLD_PLUGINS)$(NAME) $(FPIC) $(SRC) $(CXXFLAGS) && \
+	$(call YELLOW,"✅ $@") || \
+	$(call YELLOW,"❌ $@")
+
+clean:
+	@rm -f $(OBJ)
+	@$(call GREEN,"✅ [$@] done !")
+
+fclean: clean
+	@rm -f $(FLD_PLUGINS)$(NAME)
+	@$(call GREEN,"✅ [$@] done !")
+
+re:	fclean all
+
+%.o: %.cpp
+	@g++ -c $< -o $@ $(CXXFLAGS) $(FPIC) && \
+	$(call YELLOW,"🆗 $<") || \
+	$(call YELLOW,"❌ $<")

--- a/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
+++ b/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
@@ -14,15 +14,17 @@ Primitive::RectangularCuboid::RectangularCuboid() {
     _minX = 0;
     _minY = 0;
     _minZ = 0;
+    _rotation = Math::Vector3D(0, 0, 0);
 }
 
-Primitive::RectangularCuboid::RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ) {
+Primitive::RectangularCuboid::RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ, std::shared_ptr<Material::IMaterial> material) {
     _maxX = maxX;
     _maxY = maxY;
     _maxZ = maxZ;
     _minX = minX;
     _minY = minY;
     _minZ = minZ;
+    _material = material;
 }
 
 Math::Point3D Primitive::RectangularCuboid::checkRayReachPrimitive(double t, Math::Vector3D vDir, Math::Point3D origin) const
@@ -40,6 +42,12 @@ Math::Point3D Primitive::RectangularCuboid::hitPoint(const Raytracer::Ray& ray) 
 {
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
+    rayOrigin.rotateX(this->_rotation.x());
+    rayOrigin.rotateY(this->_rotation.y());
+    rayOrigin.rotateZ(this->_rotation.z());
+    rayDirection.rotateX(this->_rotation.x());
+    rayDirection.rotateY(this->_rotation.y());
+    rayDirection.rotateZ(this->_rotation.z());
 
     if (rayDirection.x() != 0) {
         double tXmin = (_minX - rayOrigin.x()) / rayDirection.x();
@@ -160,4 +168,9 @@ Math::Vector3D Primitive::RectangularCuboid::getNormal(const Math::Vector3D& hit
     if (hitPoint.z() == _minZ)
         return Math::Vector3D(0, 0, -1);
     return Math::Vector3D(-1, -1, -1);
+}
+
+void Primitive::RectangularCuboid::setRotation(Math::Vector3D rotation)
+{
+    _rotation = rotation;
 }

--- a/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
+++ b/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
@@ -1,0 +1,147 @@
+/*
+** EPITECH PROJECT, 2024
+** Raytracer
+** File description:
+** RectangularCuboid
+*/
+
+#include "Primitives/RectangularCuboid.hpp"
+
+Primitive::RectangularCuboid::RectangularCuboid() {
+    _maxX = 0;
+    _maxY = 0;
+    _maxZ = 0;
+    _minX = 0;
+    _minY = 0;
+    _minZ = 0;
+}
+
+Primitive::RectangularCuboid::RectangularCuboid(double maxX, double maxY, double maxZ, double minX, double minY, double minZ) {
+    _maxX = maxX;
+    _maxY = maxY;
+    _maxZ = maxZ;
+    _minX = minX;
+    _minY = minY;
+    _minZ = minZ;
+}
+
+Math::Point3D Primitive::RectangularCuboid::hitPoint(const Raytracer::Ray& ray) const
+{
+    Math::Point3D rayOrigin = ray.origin();
+    Math::Vector3D rayDirection = ray.direction();
+
+    double tX = 0;
+    double tY = 0;
+    double tZ = 0;
+
+    if (rayDirection.x() != 0) {
+        double t1 = (_minX - rayOrigin.x()) / rayDirection.x();
+        double t2 = (_maxX - rayOrigin.x()) / rayDirection.x();
+        tX = t1 < t2 ? t1 : t2;
+    } else {
+        return Math::Point3D(-1, -1, -1);
+    }
+    if (rayDirection.y() != 0) {
+        double t1 = (_minY - rayOrigin.y()) / rayDirection.y();
+        double t2 = (_maxY - rayOrigin.y()) / rayDirection.y();
+        tY = t1 < t2 ? t1 : t2;
+    } else {
+        return Math::Point3D(-1, -1, -1);
+    }
+    if (rayDirection.z() != 0) {
+        double t1 = (_minZ - rayOrigin.z()) / rayDirection.z();
+        double t2 = (_maxZ - rayOrigin.z()) / rayDirection.z();
+        tZ = t1 < t2 ? t1 : t2;
+    } else {
+        return Math::Point3D(-1, -1, -1);
+    }
+
+    return Math::Point3D(tX, tY, tZ);
+}
+
+double Primitive::RectangularCuboid::getMinX() const
+{
+    return _minX;
+}
+
+double Primitive::RectangularCuboid::getMinY() const
+{
+    return _minY;
+}
+
+double Primitive::RectangularCuboid::getMinZ() const
+{
+    return _minZ;
+}
+
+double Primitive::RectangularCuboid::getMaxX() const
+{
+    return _maxX;
+}
+
+double Primitive::RectangularCuboid::getMaxY() const
+{
+    return _maxY;
+}
+
+double Primitive::RectangularCuboid::getMaxZ() const
+{
+    return _maxZ;
+}
+
+void Primitive::RectangularCuboid::setMaxX(double maxX)
+{
+    _maxX = maxX;
+}
+
+void Primitive::RectangularCuboid::setMaxY(double maxY)
+{
+    _maxY = maxY;
+}
+
+void Primitive::RectangularCuboid::setMaxZ(double maxZ)
+{
+    _maxZ = maxZ;
+}
+
+void Primitive::RectangularCuboid::setMinX(double minX)
+{
+    _minX = minX;
+}
+
+void Primitive::RectangularCuboid::setMinY(double minY)
+{
+    _minY = minY;
+}
+
+void Primitive::RectangularCuboid::setMinZ(double minZ)
+{
+    _minZ = minZ;
+}
+
+std::shared_ptr<Material::IMaterial> Primitive::RectangularCuboid::getMaterial() const
+{
+    return this->_material;
+}
+
+void Primitive::RectangularCuboid::setMaterial(std::shared_ptr<Material::IMaterial> material)
+{
+    this->_material = material;
+}
+
+Math::Vector3D Primitive::RectangularCuboid::getNormal(const Math::Vector3D& hitPoint) const
+{
+    if (hitPoint.x() == _maxX)
+        return Math::Vector3D(1, 0, 0);
+    if (hitPoint.x() == _minX)
+        return Math::Vector3D(-1, 0, 0);
+    if (hitPoint.y() == _maxY)
+        return Math::Vector3D(0, 1, 0);
+    if (hitPoint.y() == _minY)
+        return Math::Vector3D(0, -1, 0);
+    if (hitPoint.z() == _maxZ)
+        return Math::Vector3D(0, 0, 1);
+    if (hitPoint.z() == _minZ)
+        return Math::Vector3D(0, 0, -1);
+    return Math::Vector3D(-1, -1, -1);
+}

--- a/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
+++ b/src/Plugins/Primitives/RectangularCuboid/RectangularCuboid.cpp
@@ -25,38 +25,54 @@ Primitive::RectangularCuboid::RectangularCuboid(double maxX, double maxY, double
     _minZ = minZ;
 }
 
+Math::Point3D Primitive::RectangularCuboid::checkRayReachPrimitive(double t, Math::Vector3D vDir, Math::Point3D origin) const
+{
+    Math::Point3D hitPoint = origin + vDir * t;
+
+    if (hitPoint.x() >= _minX && hitPoint.x() <= _maxX &&
+        hitPoint.y() >= _minY && hitPoint.y() <= _maxY &&
+        hitPoint.z() >= _minZ && hitPoint.z() <= _maxZ)
+        return hitPoint;
+    return Math::Point3D(-1, -1, -1);
+}
+
 Math::Point3D Primitive::RectangularCuboid::hitPoint(const Raytracer::Ray& ray) const
 {
     Math::Point3D rayOrigin = ray.origin();
     Math::Vector3D rayDirection = ray.direction();
 
-    double tX = 0;
-    double tY = 0;
-    double tZ = 0;
-
     if (rayDirection.x() != 0) {
-        double t1 = (_minX - rayOrigin.x()) / rayDirection.x();
-        double t2 = (_maxX - rayOrigin.x()) / rayDirection.x();
-        tX = t1 < t2 ? t1 : t2;
-    } else {
-        return Math::Point3D(-1, -1, -1);
+        double tXmin = (_minX - rayOrigin.x()) / rayDirection.x();
+        double tXmax = (_maxX - rayOrigin.x()) / rayDirection.x();
+        if (tXmin > tXmax)
+            std::swap(tXmin, tXmax);
+
+        auto hitPoint = checkRayReachPrimitive(tXmin, rayDirection, rayOrigin);
+        if (hitPoint != Math::Point3D(-1, -1, -1))
+            return hitPoint;
     }
     if (rayDirection.y() != 0) {
-        double t1 = (_minY - rayOrigin.y()) / rayDirection.y();
-        double t2 = (_maxY - rayOrigin.y()) / rayDirection.y();
-        tY = t1 < t2 ? t1 : t2;
-    } else {
-        return Math::Point3D(-1, -1, -1);
+        double tYmin = (_minY - rayOrigin.y()) / rayDirection.y();
+        double tYmax = (_maxY - rayOrigin.y()) / rayDirection.y();
+        if (tYmin > tYmax)
+            std::swap(tYmin, tYmax);
+
+        auto hitPoint = checkRayReachPrimitive(tYmin, rayDirection, rayOrigin);
+        if (hitPoint != Math::Point3D(-1, -1, -1))
+            return hitPoint;
     }
     if (rayDirection.z() != 0) {
-        double t1 = (_minZ - rayOrigin.z()) / rayDirection.z();
-        double t2 = (_maxZ - rayOrigin.z()) / rayDirection.z();
-        tZ = t1 < t2 ? t1 : t2;
-    } else {
-        return Math::Point3D(-1, -1, -1);
+        double tZmin = (_minZ - rayOrigin.z()) / rayDirection.z();
+        double tZmax = (_maxZ - rayOrigin.z()) / rayDirection.z();
+        if (tZmin > tZmax)
+            std::swap(tZmin, tZmax);
+
+        auto hitPoint = checkRayReachPrimitive(tZmin, rayDirection, rayOrigin);
+        if (hitPoint != Math::Point3D(-1, -1, -1))
+            return hitPoint;
     }
 
-    return Math::Point3D(tX, tY, tZ);
+    return Math::Point3D(-1, -1, -1);
 }
 
 double Primitive::RectangularCuboid::getMinX() const

--- a/src/Plugins/Primitives/RectangularCuboid/getInstance.cpp
+++ b/src/Plugins/Primitives/RectangularCuboid/getInstance.cpp
@@ -1,0 +1,32 @@
+/*
+** EPITECH PROJECT, 2024
+** Raytracer
+** File description:
+** Rectangular_cuboid
+*/
+
+#include <iostream>
+
+#include "RectangularCuboid.hpp"
+
+extern "C"
+{
+    __attribute__((constructor))
+    static void initsharedlibrary()
+    {
+        std::cout << "Loading Rectangular Cuboid Plugin ..." << std::endl;
+    }
+
+    Primitive::IPrimitive *getRectangularCuboidInstance()
+    {
+        Primitive::IPrimitive *rectangularCuboid = new Primitive::RectangularCuboid();
+        std::cout << "New Rectangular Cuboid created ..." << std::endl;
+        return rectangularCuboid;
+    }
+
+    __attribute__((destructor))
+    static void destroysharedlibrary()
+    {
+        std::cout << "Closing Rectangular Cuboid Plugin ..." << std::endl;
+    }
+}

--- a/tests/files_examples/subjects/subject2.cfg
+++ b/tests/files_examples/subjects/subject2.cfg
@@ -15,7 +15,7 @@ primitives :
 
     # List of rectangulars cuboids
     rectangular_cuboids = (
-    { minX = -200; minY = -105; minZ = 250; maxX = 45; maxY = 25; maxZ = 260; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};}; translation = {x = 100, y = 0, z = 0} },
+    { minX = -200; minY = -105; minZ = 250; maxX = 45; maxY = 25; maxZ = 260; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};}; translation = {x = 100, y = 0, z = 0}; rotation = {x = 0.00, y = 0.00, z = 30.0}; },
     );
 };
 

--- a/tests/files_examples/subjects/subject2.cfg
+++ b/tests/files_examples/subjects/subject2.cfg
@@ -12,6 +12,11 @@ primitives :
     cylinders = (
     { x = 6; y = -5; z = 200; r = 10; axis="X"; material = { type = "flatColor"; color = { r = 255; g = 255; b = 0;};} },
     );
+
+    # List of rectangulars cuboids
+    rectangular_cuboids = (
+    { minX = 10; minY = -5; minZ = 150; maxX = 25; maxY = 10; maxZ = 160; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};} },
+    );
 };
 
 # Light configuration

--- a/tests/files_examples/subjects/subject2.cfg
+++ b/tests/files_examples/subjects/subject2.cfg
@@ -5,7 +5,7 @@ primitives :
 {
     # # List of spheres
     spheres = (
-    { x = 6; y = -5; z = 200; r = 15; material = { type = "flatColor"; color = { r = 255; g = 64; b = 64;};} },
+    { x = 6; y = -5; z = 200; r = 15; material = { type = "flatColor"; color = { r = 255; g = 64; b = 64;};}; translation = {x = 0, y = 0, z = 0}},
     ) ;
 
     # List of cylinders
@@ -15,7 +15,7 @@ primitives :
 
     # List of rectangulars cuboids
     rectangular_cuboids = (
-    { minX = 10; minY = -5; minZ = 150; maxX = 25; maxY = 10; maxZ = 160; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};} },
+    { minX = -200; minY = -105; minZ = 250; maxX = 45; maxY = 25; maxZ = 260; material = { type = "flatColor"; color = { r = 255; g = 0; b = 255;};}; translation = {x = 100, y = 0, z = 0} },
     );
 };
 


### PR DESCRIPTION
I've added the Rectangular Cuboid Primitive.

For build a Rectangular Cuboid primitive, go in a .cfg file in primitives part, you can create a `rectangular_cuboid` container. All the rectangular cuboid follow this build : minX, minY, minZ, maxX, maxY and maxZ. This is the position of extrem point of the Rectangular Cuboid primitive.

You have a result like this: 
![image](https://github.com/Njord201/Raytracer/assets/114904525/466c082f-d9e7-4afb-a0f1-0962759edc23)
 For this configuration:
![image](https://github.com/Njord201/Raytracer/assets/114904525/b3a4aab6-d619-4d3b-ba40-d14dc86fa231)
